### PR TITLE
[no-ticket] Change module to Superbet-group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sethgrid/pester
+module github.com/superbet-group/pester
 
 go 1.14


### PR DESCRIPTION
I honestly don't know what is the policy regarding this, but unless this is changed, I cannot use it in our calculator.