### PR TITLE
[no-ticket] Use functions compatible with Go v1.14

### DIFF
--- a/pester.go
+++ b/pester.go
@@ -222,9 +222,9 @@ func (c *Client) copyBody(src io.ReadCloser) ([]byte, error) {
 // the originalBody. This is used to refresh http.Requests that may have had their
 // bodies closed already.
 func resetBody(request *http.Request, originalBody []byte) {
-	request.Body = io.NopCloser(bytes.NewBuffer(originalBody))
+	request.Body = ioutil.NopCloser(bytes.NewBuffer(originalBody))
 	request.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewBuffer(originalBody)), nil
+		return ioutil.NopCloser(bytes.NewBuffer(originalBody)), nil
 	}
 }
 


### PR DESCRIPTION
There are 2 ways to solve this. One is to use functions defined in the `ioutil` package of the standard lib. The other is to increase the Go version this package requires.

Increasing Go version would require increasing Go version on our base docker image, propagating that through our repo, etc.

This seemed like a much simpler solution. 